### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/config/default/fail2ban/Dockerfile
+++ b/config/default/fail2ban/Dockerfile
@@ -1,3 +1,3 @@
-FROM crazymax/fail2ban:0.10.4
+FROM crazymax/fail2ban:fail2ban
 CMD ["fail2ban-server", "-f", "-x", "-v", "start"]
 HEALTHCHECK --interval=100s --timeout=5s CMD fail2ban-client ping || exit 1


### PR DESCRIPTION
`crazymax/fail2ban` changed recently. This pull request ensures you're using the latest version of the image and changes `crazymax/fail2ban` to the latest tag: `fail2ban`

New base image: `crazymax/fail2ban:fail2ban`